### PR TITLE
v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,17 +292,17 @@ A (canonicalized) [JWT] signed with [`secp256k1`] would be strucutured as follow
 
 ```
     Varsig
-  Multiformat      Signature         Payload
-    Prefix         Metadata         Encoding
-  ┌────┴───┐┌──────────┴─────────┐┌─────┴────┐
-  │        ││ ┏━━━━┓┏━━━━┓┏━━━━┓ ││ ┏━━━━━━┓ │
-  │  0x34  ││ ┃0xEC┃┃0xE7┃┃0x1B┃ ││ ┃0x6A77┃ │
-  │        ││ ┗━━▲━┛┗━━▲━┛┗━━▲━┛ ││ ┗━━━▲━━┛ │
-  └────────┘└────┼─────┼─────┼───┘└─────┼────┘
-                 │     │     │          │
-               ECDSA   │ Keccak-256    JWT
+  Multiformat      Signature           Payload
+    Prefix         Metadata            Encoding
+  ┌────┴───┐┌───────────┴──────────┐┌─────┴────┐
+  │        ││ ┏━━━━┓┏━━━━━━┓┏━━━━┓ ││ ┏━━━━━━┓ │
+  │  0x34  ││ ┃0xEC┃┃0x1200┃┃0x1B┃ ││ ┃0x6A77┃ │
+  │        ││ ┗━━▲━┛┗━━▲━━━┛┗━━▲━┛ ││ ┗━━━▲━━┛ │
+  └────────┘└────┼─────┼───────┼───┘└─────┼────┘
+                 │     │       │          │
+               ECDSA   │   Keccak-256    JWT
                        │
-                   secp256k1
+                     P-256
 ```
 
 ### Varsig Prefix

--- a/README.md
+++ b/README.md
@@ -327,12 +327,12 @@ The [IPLD] data model is encoding agnostic by design. This is very convenient in
 
 ``` abnf
 varsig-encoding-info
-  = %x5F                 ; Single verbatim payload (without key)
-  / %x70                 ; DAG-PB multicodec prefix
-  / %x71                 ; DAG-CBOR multicodec prefix
-  / %x0129               ; DAG-JSON multicodec prefix
-  / %x6A77               ; JWT
-  / %xE191 encoding-info ; EIP-191 "personal sign"
+  = %x5F                        ; Single verbatim payload (without key)
+  / %x70                        ; DAG-PB multicodec prefix
+  / %x71                        ; DAG-CBOR multicodec prefix
+  / %x0129                      ; DAG-JSON multicodec prefix
+  / %x6A77                      ; JWT
+  / %xE191 varsig-encoding-info ; EIP-191 "personal sign"
 ```
 
 ## Signature Bytes

--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ The prefix of the signature algorithm. This is often the [multicodec] of the ass
 A varsig header MUST begin with one or more varsig segments that desicribe.....
 
 ```abnf
-varsig-header = %x34 varsig-header
-varsig-header = unsigned-varint
-signature = *OCTET; Zero or more segments required by the kind of varsig (e.g. raw bytes, hash algorithm, etc)
+varsig-header = %x34 signature-algorithm-metadata payload-encoding-metadata
+signature-algorithm-metadata = unsigned-varint
+payload-encoding-metadata = unsigned-varint
 ```
 
 ```
@@ -268,39 +268,7 @@ signature = *OCTET; Zero or more segments required by the kind of varsig (e.g. r
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Varsig Prefix
-
-The varsig prefix MUST be the constant `0x34`.
-
-### Signature Algorithm Metadata
-
-The varsig body MUST consist of one or more segments, and MUST be defined by the signature algorithm.
-
-Some examples include:
-
-* Raw signature bytes only
-* CID of [DKIM] certification transparency record, and raw signature bytes
-* Hash algorithm multicodec prefix, data encoding prefix, signature counter, nonce, HMAC, and raw signature bytes
-
-### Payload Encoding Metadata
-
-The [IPLD] data model is encoding agnostic by design. This is very convenient in many applications, such as making for very convenient conversions between types for transmission versus encoding. Unfortunately signatures require signing over specific bytes, and thus over a specific encoding of the data.
-
-To facilitate this, the type `encoding-info` MAY be used:
-
-``` abnf
-encoding-info
-  = %x5F   ; Single verbatim payload (without key)
-  / %x70   ; DAG-PB multicodec prefix
-  / %x71   ; DAG-CBOR multicodec prefix
-  / %x0129 ; DAG-JSON multicodec prefix
-  / %x6A77 ; JWT
-  / %xE191 encoding-info ; EIP-191
-```
-
-MESSAGE LENGTH FIXME
-
-To manage this, it is RECOMMENDED that varsig types include a nested encoding multiformat. For example, here's a 2048-bit RS256 signature over some DAG-CBOR:
+For example, here's a 2048-bit RS256 signature over some DAG-CBOR:
 
 
 ```
@@ -338,6 +306,41 @@ Here is another showing a canonicalized [JWT] signed with [`secp256k1`]:
                   Keccak-256
 ```
 
+### Varsig Prefix
+
+The varsig prefix MUST be the constant `0x34`.
+
+### Signature Algorithm Metadata
+
+The varsig body MUST consist of one or more segments, and MUST be defined by the signature algorithm.
+
+Some examples include:
+
+* Raw signature bytes only
+* CID of [DKIM] certification transparency record, and raw signature bytes
+* Hash algorithm multicodec prefix, data encoding prefix, signature counter, nonce, HMAC, and raw signature bytes
+
+Here is a table of 
+
+### Payload Encoding Metadata
+
+The [IPLD] data model is encoding agnostic by design. This is very convenient in many applications, such as making for very convenient conversions between types for transmission versus encoding. Unfortunately signatures require signing over specific bytes, and thus over a specific encoding of the data.
+
+To facilitate this, the type `encoding-info` MAY be used:
+
+``` abnf
+encoding-info
+  = %x5F   ; Single verbatim payload (without key)
+  / %x70   ; DAG-PB multicodec prefix
+  / %x71   ; DAG-CBOR multicodec prefix
+  / %x0129 ; DAG-JSON multicodec prefix
+  / %x6A77 ; JWT
+  / %xE191 encoding-info ; EIP-191
+```
+
+MESSAGE LENGTH FIXME
+
+To manage this, it is RECOMMENDED that varsig types include a nested encoding multiformat.
 
 
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-> [!abstract]
-> Varsig is a [multiformat][Multiformats] for describing signatures over IPLD data and raw bytes in a way that preserves information about the payload and canonicalization information.
+Varsig is a [multiformat][Multiformats] for describing signatures over IPLD data and raw bytes in a way that preserves information about the payload and canonicalization information.
 
 # Introduction
 
@@ -173,7 +172,8 @@ Ipld::Map([
 ]);
 ```
 
-Note that the IPLD parser has dropped the `role: "admin"` key.
+> [!NOTE]
+> Above, IPLD parser has dropped the `role: "admin"` key.
 
 The `"sig"` field is then removed, and the remaining fields serialized to binary;
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Varsig Specification v0.1.0
+# Varsig Specification v0.2.0
 
 ## Editors
 
-* [Irakli Gozalishvili](https://github.com/Gozala), [DAG House](https://dag.house/)
-* [Brooklyn Zelenka](https://github.com/expede/), [Fission](https://fission.codes/)
+* [Irakli Gozalishvili](https://github.com/Gozala)
+* [Brooklyn Zelenka](https://github.com/expede/)
 
 ## Authors
 
-* [Irakli Gozalishvili](https://github.com/Gozala), [DAG House](https://dag.house/)
-* [Joel Thorstensson](https://github.com/oed), [3Box Labs](https://3boxlabs.com/)
-* [Quinn Wilton](https://github.com/QuinnWilton/), [Fission](https://fission.codes/)
-* [Brooklyn Zelenka](https://github.com/expede/), [Fission](https://fission.codes/)
+* [Irakli Gozalishvili](https://github.com/Gozala)
+* [Joel Thorstensson](https://github.com/oed)
+* [Quinn Wilton](https://github.com/QuinnWilton/)
+* [Brooklyn Zelenka](https://github.com/expede/)
 
 ## Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119].
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14] when, and only when, they appear in all capitals, as shown here.
 
 ## Dependencies
 
@@ -22,19 +22,25 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 * [Multibase]
 * [Multicodec]
 
-# 0 Abstract
+# Abstract
 
 Varsig is a [multiformat][Multiformats] for describing signatures over IPLD data and raw bytes in a way that preserves information about the payload and canonicalization information.
 
-# 1 Introduction
+# Introduction
 
 [IPLD] is a deterministic encoding scheme for data expressed in [common types][IPLD Data Model] plus content addressed links. 
 
-Common formats such as JWT use encoding (e.g. base64) and text separators (e.g. `"."`) to pass around encoded data and their signatures:
+Common formats such as [JWT][RFC 7519] use encoding (e.g. [base64]) and text separators (e.g. `"."`) to pass around encoded data and their signatures:
 
 ``` js
 // JWT
-"eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWtyNWFlZmluMUR6akc3TUJKM25zRkNzbnZIS0V2VGIyQzRZQUp3Ynh0MWpGUyIsImF0dCI6W3sid2l0aCI6eyJzY2hlbWUiOiJ3bmZzIiwiaGllclBhcnQiOiIvL2RlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyJ9LCJjYW4iOnsibmFtZXNwYWNlIjoid25mcyIsInNlZ21lbnRzIjpbIk9WRVJXUklURSJdfX1dLCJleHAiOjkyNTY5Mzk1MDUsImlzcyI6ImRpZDprZXk6ejZNa2tXb3E2UzN0cVJXcWtSbnlNZFhmcnM1NDlFZnU2cUN1NHVqRGZNY2pGUEpSIiwicHJmIjpbXX0.SjKaHG_2Ce0pjuNF5OD-b6joN1SIJMpjKjjl4JE61_upOrtvKoDQSxZ7WeYVAIATDl8EmcOKj9OqOSw0Vg8VCA"
+"eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJhdWQiOiJkaWQ6a2V5Ono
+2TWtyNWFlZmluMUR6akc3TUJKM25zRkNzbnZIS0V2VGIyQzRZQUp3Ynh0MWpGUyIsImF0dCI6W3sid2l
+0aCI6eyJzY2hlbWUiOiJ3bmZzIiwiaGllclBhcnQiOiIvL2RlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJ
+saWMvcGhvdG9zLyJ9LCJjYW4iOnsibmFtZXNwYWNlIjoid25mcyIsInNlZ21lbnRzIjpbIk9WRVJXUkl
+URSJdfX1dLCJleHAiOjkyNTY5Mzk1MDUsImlzcyI6ImRpZDprZXk6ejZNa2tXb3E2UzN0cVJXcWtSbnl
+NZFhmcnM1NDlFZnU2cUN1NHVqRGZNY2pGUEpSIiwicHJmIjpbXX0.SjKaHG_2Ce0pjuNF5OD-b6joN1S
+IJMpjKjjl4JE61_upOrtvKoDQSxZ7WeYVAIATDl8EmcOKj9OqOSw0Vg8VCA"
 ```
 
 Many binary-as-text encodings are inefficient and inconvenient. Others have opted to use canonicalization and a tag. This can be effective, but requires careful handling and signalling of the specific canonicalization method used.
@@ -46,15 +52,15 @@ const payload = canonicalize({"hello": "world", "count": 42})
 
 Directly signing over canonicalized data introduces new problems: forced encoding and canonicalization attacks.
 
-## 1.1 Forced Encoding
+## Forced Encoding
 
-Data must first be rendered to binary before it is signed. This means imposing an encoding. There is no standard way to include the encoding that some IPLD was encoded with other than a CID. In IPFS, CIDs imply a link, which can have implications for network access and storage. Further, generating a CID means producing a hash, which is then potentially rehashed by the cryptographic signature library.
+Data must first be rendered to binary before it is signed. This means imposing some encoding. There is no standard way to include the encoding that some IPLD was encoded with other than a [CID]. In IPFS, CIDs imply a link, which can have implications for network access and storage. Further, generating a CID means producing a hash, which is then potentially rehashed to conform to the cryptographic signature algorithm. 
 
 To remedy this, varsig includes the encoding information used in production of the signature.
 
-## 1.2 Canonicalization Attacks
+## Canonicalization Attacks
 
-Since IPLD is deterministically encoded, it can be tempting to rely on canonicalization at validation time, rather than rendering the IPLD to inline bytes or a CID and signing that. Since the original payload can be rederived from the output, this seems like a clean option:
+Since IPLD is deterministically encoded, it can be tempting to rely on canonicalization at validation time, rather than rendering the IPLD to inline bytes or a CID and signing that. Since the original payload can be rederived from the output, this can seem like a clean option:
 
 ``` js
 // DAG-JSON
@@ -69,11 +75,11 @@ Since IPLD is deterministically encoded, it can be tempting to rely on canonical
 }
 ```
 
-This opens the potential for [canonicalization attacks]. Parsers for certain formats — such as JSON — are known to handle duplicate entries differently. IPLD needs to be serialized to a canonical form before checking the signature. Without careful handling, it is possible to fail to check if any additional fields have been added to the payload which will be parsed by the application. 
+Unfortunately this opens the potential for [canonicalization attacks]. Parsers for certain formats — such as JSON — are known to handle duplicate entries differently. IPLD MUST to be serialized to a canonical form before checking the signature. Without careful handling, it is possible to fail to check if any additional fields have been added to the payload which will be parsed by the application. 
 
 > An object whose names are all unique is interoperable in the sense that all software implementations receiving that object will agree on the name-value mappings.  When the names within an object are not unique, the behavior of software that receives such an object is unpredictable.  Many implementations report the last name/value pair only.  Other implementations report an error or fail to parse the object, and some implementations report all of the name/value pairs, including duplicates.
 >
-> — [RFC8259]
+> — [RFC 8259]
 
 ``` json
 {
@@ -88,13 +94,13 @@ This opens the potential for [canonicalization attacks]. Parsers for certain for
 }
 ```
 
-In the above example, the canonicalization step MAY lead to the signature validating, but the client parsing the `role: "admin"` field instead.
+In the above example, the canonicalization step MAY lead to the signature passing validation, but the client parsing the `role: "admin"` field instead.
 
-## 1.2.1 Example
+### Example
 
 The above can be [quite subtle][PKI Layer Cake]. Here is a step by step example of one such scenario.
 
-An application receives some block of data, as binary. It checks the claimed CID, which validates.
+An application receives some block of data, as binary. It checks the claimed CID, which passes validation.
 
 ```
 %x7ba202022726f6c65223a202275736572222ca202022726f6c65223a202261646d696e222ca2020226c696e6b73223a205ba202020207b222f223a20226261666b72656964623271336b7467746c6d3579696f3762756a337379707967686a7466683565726e737465716d616b66347032633562776d7969227d2c20202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020207b222f223a20226261666b72656963373579646735766b773332346f716b636d716c74667663336b6976796e67716b69626a6f7973647769696c616b68347a356665227d2ca202020207b222f223a20226261666b726569666664697a3672616634367a727233623275737566677a35666f34346167676d6f637a347a61707072366b6868686c6a63647079227da20205d2ca202022736967223a2022387566615339773343474e386362515455536f4c31693765614b69574c53587344324c625a566d764d397a4622a7d
@@ -134,7 +140,7 @@ Next, the application parses the JSON with the browser's native JSON parser.
 The application MUST check the signature of all field minus the `sig` field. Under the assumption that the binary input was safe, and that canonicalization allows for the deterministic manipulation of the payload, the object is parsed to an internal IPLD representation using Rust/Wasm.
 
 ``` Rust
-Ipld::Assoc([
+Ipld::Map([
     ("role", Ipld::String("user")),
     (
         "links",
@@ -147,9 +153,9 @@ Ipld::Assoc([
     (
         "sig",
         Ipld::Binary([
-            %xf2, %xe7, %xda, %x4b, %xdc, %x37, %x08, %x63, %x7c, %x71, %xb4, %x13, %x51, %x2a,
-            %x0b, %xd6, %x2e, %xde, %x68, %xa8, %x96, %x2d, %x25, %xec, %x0f, %x62, %xdb, %x65,
-            %x59, %xaf, %x33, %xdc, %xc5,
+            0xf2, 0xe7, 0xda, 0x4b, 0xdc, 0x37, 0x08, 0x63, 0x7c, 0x71, 0xb4, 0x13, 0x51, 0x2a,
+            0x0b, 0xd6, 0x2e, 0xde, 0x68, 0xa8, 0x96, 0x2d, 0x25, 0xec, 0x0f, 0x62, 0xdb, 0x65,
+            0x59, 0xaf, 0x33, 0xdc, 0xc5,
         ]),
     ),
 ]);
@@ -160,8 +166,8 @@ Note that the IPLD parser has dropped the `role: "admin"` key.
 The `"sig"` field is then removed, and the remaining fields serialized to binary;
 
 ``` Rust
-Ipld::DagJson::serialize(
-    Ipld::Assoc([
+Ipld::serialize(
+    Ipld::Map([
         ("role", Ipld::String("user")),
         (
             "links",
@@ -172,12 +178,12 @@ Ipld::DagJson::serialize(
             ]),
         )
     ])
-);
+).to_json();
 ```
 
 The signature is then checked against the above fields, which passes since there's only a `role: "user"` entry. The application then uses the original JSON with the `role: "admin"` entry.
 
-# 2 Safety
+# Safety
 
 Data that has already been parsed to an in-memory IPLD representation can be canonically encoded trivially: it has already been through a [parser / validator][Parse Don't Validate].
 
@@ -185,49 +191,88 @@ Data purporting to conform to an IPLD encoding (such as [DAG-JSON]) MUST be vali
 
 > [Implementers] may provide an opt-in for systems where round-trip determinism is a desireable [sic] feature and backward compatibility with old, non-strict data is unnecessary.
 >
-> — [DAG-JSON Spec][DAG-JSON]
+> — [DAG-JSON Spec][DAG-JSON]
 
 As it is critical for guarding against various attacks, the assumptions around canonical encoding MUST be enforced.
 
-## 2.1 Signing CIDs
+## Signing CIDs
 
-Rather than validating the inline IPLD, replacing the data with a CID link to the content MAY be used instead. Note while this is very safe (as it is impractical to alter a signed hash), this approach mixes data layout with security, and may have a performance, disk, and networking impacts.
+Rather than validating the inline IPLD, replacing the data with a CID link to the content MAY be used instead. Note while this is very safe (as it is impractical to alter a signed hash), this approach mixes data layout with security, and may have a performance, storage, data availability, and networking consequences.
 
-### 2.1.1 Caching & Invalidation
+### Caching & Invalidation
 
 Signing CIDs has two additional caching consequences:
 
 1. Signing CIDs enables a simple strategy for caching validation by CID.
 2. Such a strategy also MAY require accounting for revocation of the signing keys themselves. In this case, the cache would need to include additional information about the signing key.
 
-## 2.2 Raw (Noncanonicalized) Data
+## Raw (Noncanonicalized) Data
 
 Canonicalization is not required if data is encoded as raw bytes (multicodec `%x55`). The exact bytes are already present, and MUST not be changed.
 
-# 3 Varsig Format
+# Format
 
-After being decoded from [unsigned varint]s, a varsig includes the following segments:
+A varsig is composed of two main segments:
 
-```abnf
-varsig = multibase-prefix %x34 varsig-header varsig-body
-multibase-prefix = ALPHA ; Multibase
-varsig-header = unsigned-varint ; Usually the public key code from Multicodec
-varsig-body = *OCTET; Zero or more segments required by the kind of varsig (e.g. raw bytes, hash algorithm, etc)
+* [Header]: binary coded signature metadata
+* [Signature]: the signature itself
+
+Including the varsig header in the payload that is signed over is RECOMMENDED. Doing so eliminates any ambiguity of the signed payload format and signature algorithm configuration.
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════════╗ ╔══════════════════════╗
+║                                     Payload                                       ║ ║                      ║
+║ ┌───────────────────────────────────────────────────────────────────────────────┐ ║ ║                      ║
+║ │                                Varsig Header                                  │ ║ ║                      ║
+║ │ ┌───────────────┬──────────────────────────────┬────────────────────────────┐ │ ║ ║                      ║
+║ │ │ Varsig Prefix │ Signature Algorithm Metadata │ Payload Encoding Metadata  │ │ ║ ║   Signature Bytes    ║
+║ │ └───────────────┴──────────────────────────────┴────────────────────────────┘ │ ║ ║                      ║
+║ └───────────────────────────────────────────────────────────────────────────────┘ ║ ║                      ║
+║ ┌───────────────────────────────────────────────────────────────────────────────┐ ║ ║                      ║
+║ │                              ...data to sign...                               │ ║ ║                      ║
+║ └───────────────────────────────────────────────────────────────────────────────┘ ║ ║                      ║
+╚═══════════════════════════════════════════════════════════════════════════════════╝ ╚══════════════════════╝
 ```
 
-For example, here is an EdDSA signature for some content encoded as DAG-PB:
+## Header
 
-`%x34ed01ae3784f03f9ee1163382fa6efa73b0c31ecf58c899c836709303ba4621d1e6df20e09aaa568914290b7ea124f5b38e70b9b69c7de0d216880eac885edd41c302`
+The header contains metadata about both the signature and payload that was signed over. Since the 
 
-### 3.1 Varsig Prefix
+A varsig header MUST begin with one or more varsig segments that desicribe.....
 
-The varsig prefix MUST be `%x34`.
+```abnf
+varsig-header = %x34 varsig-header
+multibase-prefix = ALPHA
+varsig-header = unsigned-varint
+signature = *OCTET; Zero or more segments required by the kind of varsig (e.g. raw bytes, hash algorithm, etc)
+```
 
-### 3.2 Signature Header
+
+``` abnf
+┌──────────────────────────────┬───────────────────────────┐
+│ signature algorithm metadata │ payload encoding metadata │
+└──────────────────────────────┴───────────────────────────┘
+```
+
+```abnf
+varsig-header = 
+varsig-sig-meta = 1*unsigned-varint ; Usually the public key code from Multicodec
+varsig-payload-meta = 1*unsigned-varint
+```
+
+## Signature
+
+The signature 
+
+## Varsig Prefix
+
+The varsig prefix MUST be `0x34`.
+
+## Signature Header
 
 The prefix of the signature algorithm. This is often the [multicodec] of the associated public key, but MAY be unique for the signature type. The code MAY live outside the multicodec table. This field MUST act as a discriminant for how many expected fields come in the varsig body, and what each of them mean.
 
-### 3.3 Varsig Body
+## Varsig Body
 
 The varsig body MUST consist of one or more segments, and MUST be defined by the signature algorithm.
 
@@ -237,7 +282,7 @@ Some examples include:
 * CID of [DKIM] certification transparency record, and raw signature bytes
 * Hash algorithm multicodec prefix, data encoding prefix, signature counter, nonce, HMAC, and raw signature bytes
 
-# 4 Payload Encoding
+# Payload Encoding
 
 The [IPLD] data model is encoding agnostic by design. This is very convenient in many applications, such as making for very convenient conversions between types for transmission versus encoding. Unfortunately signatures require signing over specific bytes, and thus over a specific encoding of the data.
 
@@ -257,35 +302,47 @@ message-byte-length = unsigned-varint
 
 To manage this, it is RECOMMENDED that varsig types include a nested encoding multiformat. For example, here's a 2048-bit RS256 signature over some DAG-CBOR:
 
-``` abnf
-;    RSA       256-bytes       sig-bytes
-;     |           |               |
-;     v           v               v
-%x34 %x1205 %x12 %x0100 %x71 256(OCTET)
-; ^          ^           ^
-; |          |           |
-;varsig   SHA-256     DAG-CBOR
+
+```
+    Varisg
+  Multiformat                      DAG-CBOR
+    Prefix         Signature  (Payload Encoding)
+       │           Metadata            │
+       ▼  ┌────────────┴───────────┐   ▼
+    ┌────┐│ ┌──────┐┌────┐┌──────┐ │┌────┐
+    │0x34││ │0x1205││0x12││0x0100│ ││0x71│
+    └────┘│ └──────┘└────┘└──────┘ │└────┘
+          └─────▲──────▲──────▲────┘
+                │      │      │
+               RSA  SHA-256   │
+                              │
+                          256-bytes
+                         (2048-bits)
 ```
 
-And another showing data signed with [EIP-191]:
+Here is another showing a canonicalized [JWT] signed with [`secp256k1`]:
 
-``` abnf
-; secp256k1  EIP-191
-;     |         |
-;     v         v
-%x34 %xE7 %x1B %xE191 64(OCTET)
-; ^        ^            ^
-; |        |            |
-;varsig keccak-256   sig-bytes
+```
+    Varisg                       JWT
+  Multiformat            (Payload Encoding)
+    Prefix     Signature          │
+       │       Metadata           │
+       ▼  ┌────────┴─────────┐    ▼
+    ┌────┐│ ┌──────┐┌──────┐ │┌──────┐
+    │0x34││ │ 0xE7 ││ 0x1B │ ││0x6A77│
+    └────┘│ └──────┘└──────┘ │└──────┘
+          └─────▲──────▲─────┘
+                │      │
+            secp256k1  │
+                       │
+                  Keccak-256
 ```
 
-Note that in the above examples, more nested information MAY be nested inside the encoding info section, depending on the definition of the encoding info.
-
-# 5 Registry of Common Signature Algorithms
+# Registry of Common Signature Algorithms
 
 Below are a few common signature headers and their fields.
 
-## 5.1 RSA
+## RSA
 
 RSASSA-PKCS #1 v1.5 signatures MUST include the following segments:
 
@@ -299,21 +356,21 @@ encoding-info = 1*unsigned-varint ; Number of segments defined by the encoding h
 sig-bytes = *OCTET
 ```
 
-### 5.1.1 Example: RS256
+### Example: RS256
 
 | Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
 |----------------------|-------------|-----------------|-----------------------------------------|
 | `rsa-varsig-header`  | `%x1205`    | `%x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
 | `rsa-hash-algorithm` | `%x12`      | `%x12`          | SHA2-256 [multicodec] prefix            |
 
-### 5.1.3 Example: RS512
+### Example: RS512
 
 | Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
 |----------------------|-------------|-----------------|-----------------------------------------|
 | `rsa-varsig-header`  | `%x1205`    | `%x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
 | `rsa-hash-algorithm` | `%x13`      | `%x13`          | SHA2-512 [multicodec] prefix            |
 
-## 5.2 Ed25519
+## Ed25519
 
 ``` abnf
 ed25519-varsig = ed25519-varsig-header encoding-info sig-bytes
@@ -327,7 +384,7 @@ sig-bytes = 32(OCTET)
 |-------------------------|-------------|-----------------|---------------------------------|
 | `ed25519-varsig-header` | `%xED`      | `%xED01`        | Ed25519 key [multicodec] prefix |
 
-## 5.3 ECDSA
+## ECDSA
 
 ECDSA defines a general mechanism over many elliptic curves. 
 
@@ -342,7 +399,7 @@ sig-bytes = *OCTET
 
 Here are a few examples encoded as varsig:
 
-### 5.3.1 Example: ES256
+### Example: ES256
 
 ``` abnf
 es256-varsig = es256-varsig-header es256-hash-algorithm encoding-info sig-bytes
@@ -358,7 +415,7 @@ sig-bytes = 64(OCTET)
 | `es256-varsig-header`  | `%x1200`    | `%x8024`        | P-256 [multicodec] prefix    |
 | `es256-hash-algorithm` | `%x12`      | `%x12`          | SHA2-256 [multicodec] prefix |
 
-### 5.3.2 Example: ES256K
+### Example: ES256K
 
 ``` abnf
 es256k-varsig = es256k-varsig-header es256k-hash-algorithm encoding-info sig-bytes
@@ -374,7 +431,7 @@ sig-bytes = 64(OCTET)
 | `es256k-varsig-header`  | `%xE7`      | `%xE701`        | secp256k1 [multicodec] prefix  |
 | `es256k-hash-algorithm` | `%x12`      | `%x12`          | SHA2-256 [multicodec] prefix   |
 
-### 5.3.3 Example: ES512
+### Example: ES512
 
 ``` abnf
 es512-varsig = es512-varsig-header es512-hash-algorithm encoding-info sig-bytes
@@ -397,8 +454,15 @@ sig-bytes = 128(OCTET)
 * [A Taxonomy of Attacks against XML Digital Signatures & Encryption][Taxonomy of Attacks]
 * [PKI Layer Cake]
 
-[Taxonomy of Attacks]: https://www.blackhat.com/presentations/bh-usa-07/Hill/Whitepaper/bh-usa-07-hill-WP.pdf
+<!-- Internal Links -->
+
+[Header]: #header
+[Signature]: #signature
+
+<!-- External Links -->
+
 [CAR]: https://ipld.io/specs/transport/car/
+[CID]: https://docs.ipfs.tech/concepts/content-addressing/
 [DAG-JSON]: https://ipld.io/specs/codecs/dag-json/spec/
 [DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
 [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
@@ -410,7 +474,11 @@ sig-bytes = 128(OCTET)
 [PKI Layer Cake]: https://link.springer.com/chapter/10.1007/978-3-642-14577-3_22
 [Parse Don't Validate]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
-[RFC8259]: https://www.rfc-editor.org/rfc/rfc8259#page-10
+[RFC 7519]: https://www.rfc-editor.org/rfc/rfc7519
+[RFC 8259]: https://www.rfc-editor.org/rfc/rfc8259#page-10
+[Taxonomy of Attacks]: https://www.blackhat.com/presentations/bh-usa-07/Hill/Whitepaper/bh-usa-07-hill-WP.pdf
+[`secp256k1`]: https://en.bitcoin.it/wiki/Secp256k1
+[base64]: https://en.wikipedia.org/wiki/Base64
 [canonicalization attacks]: https://soatok.blog/2021/07/30/canonicalization-attacks-against-macs-and-signatures/
 [multibase]: https://github.com/multiformats/multibase
 [multicodec]: https://github.com/multiformats/multicodec

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To remedy this, varsig includes the encoding information used in production of t
 
 Since IPLD is deterministically encoded, it can be tempting to rely on canonicalization at validation time, rather than rendering the IPLD to inline bytes or a CID and signing that. Since the original payload can be rederived from the output, this can seem like a clean option:
 
-``` js copy
+```javascript copy
 // DAG-JSON
 {
   "role": "user",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Abstract
 
-Varsig is a [multiformat][Multiformats] for describing signatures over IPLD data and raw bytes in a way that preserves information about the payload and canonicalization information.
+> [!abstract]
+> Varsig is a [multiformat][Multiformats] for describing signatures over IPLD data and raw bytes in a way that preserves information about the payload and canonicalization information.
 
 # Introduction
 
@@ -247,9 +248,7 @@ Including the varsig header in the payload that is signed over is RECOMMENDED. D
 
 ## Header
 
-The header contains metadata about both the signature and payload that was signed over. Since the 
-
-The prefix of the signature algorithm. This is often the [multicodec] of the associated public key, but MAY be unique for the signature type. The code MAY live outside the multicodec table. This field MUST act as a discriminant for how many expected fields come in the varsig body, and what each of them mean.
+A varsig header MUST metadata about both the [signature] and [payload encoding] that was signed over. Either field MAY be composed of one or more segments. The number of segments MUST be determined by the first segment. Recurive sub-segments MAY be used.
 
 A varsig header MUST begin with one or more varsig segments that desicribe.....
 
@@ -268,9 +267,8 @@ payload-encoding-metadata = unsigned-varint
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-For example, here's a 2048-bit RS256 signature over some DAG-CBOR:
-
-
+For example, an [RS256] signature over some [DAG-CBOR] would be structured as follows:
+ 
 ```
     Varisg
   Multiformat                      DAG-CBOR
@@ -288,7 +286,7 @@ For example, here's a 2048-bit RS256 signature over some DAG-CBOR:
                          (2048-bits)
 ```
 
-Here is another showing a canonicalized [JWT] signed with [`secp256k1`]:
+A (canonicalized) [JWT] signed with [`secp256k1`] would be strucutured as follows:
 
 ```
     Varisg                       JWT
@@ -308,9 +306,12 @@ Here is another showing a canonicalized [JWT] signed with [`secp256k1`]:
 
 ### Varsig Prefix
 
-The varsig prefix MUST be the constant `0x34`.
+The varsig prefix MUST be the [multicodec] value `0x34`.
 
 ### Signature Algorithm Metadata
+
+This is often the [multicodec] of the associated public key, but MAY be unique for the signature type. The code MAY live outside the multicodec table. This field MUST act as a discriminant for how many expected fields come in the varsig body, and what each of them mean.
+
 
 The varsig body MUST consist of one or more segments, and MUST be defined by the signature algorithm.
 
@@ -319,8 +320,6 @@ Some examples include:
 * Raw signature bytes only
 * CID of [DKIM] certification transparency record, and raw signature bytes
 * Hash algorithm multicodec prefix, data encoding prefix, signature counter, nonce, HMAC, and raw signature bytes
-
-Here is a table of 
 
 ### Payload Encoding Metadata
 
@@ -475,6 +474,7 @@ sig-bytes = 128(OCTET)
 
 [Header]: #header
 [Signature]: #signature
+[Common Signature Algorithms]: #common-signature-algorithms
 
 <!-- External Links -->
 
@@ -483,9 +483,11 @@ sig-bytes = 128(OCTET)
 [DAG-JSON]: https://ipld.io/specs/codecs/dag-json/spec/
 [DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
 [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
+[EdDSA]: https://datatracker.ietf.org/doc/html/rfc8032
 [How (not) to sign a JSON object]: https://latacora.micro.blog/2019/07/24/how-not-to.html
 [IPLD Data Model]: https://ipld.io/docs/data-model/kinds/
 [IPLD]: https://ipld.io/docs/
+[JWT]: https://www.rfc-editor.org/rfc/rfc7519
 [Multicodec]: https://github.com/multiformats/multicodec
 [Multiformats]: https://multiformats.io
 [PKI Layer Cake]: https://link.springer.com/chapter/10.1007/978-3-642-14577-3_22
@@ -493,6 +495,7 @@ sig-bytes = 128(OCTET)
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
 [RFC 7519]: https://www.rfc-editor.org/rfc/rfc7519
 [RFC 8259]: https://www.rfc-editor.org/rfc/rfc8259#page-10
+[RSASSA-PKCS #1 v1.5]: https://www.rfc-editor.org/rfc/rfc2313
 [Taxonomy of Attacks]: https://www.blackhat.com/presentations/bh-usa-07/Hill/Whitepaper/bh-usa-07-hill-WP.pdf
 [`secp256k1`]: https://en.bitcoin.it/wiki/Secp256k1
 [base64]: https://en.wikipedia.org/wiki/Base64
@@ -501,5 +504,3 @@ sig-bytes = 128(OCTET)
 [multicodec]: https://github.com/multiformats/multicodec
 [raw binary multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L40
 [unsigned varint]: https://github.com/multiformats/unsigned-varint
-[EdDSA]: https://datatracker.ietf.org/doc/html/rfc8032
-[RSASSA-PKCS #1 v1.5]: https://www.rfc-editor.org/rfc/rfc2313

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ For example, an [RS256] signature over some [DAG-CBOR] is as follows:
                             SHA2-256
 ```
 
-A (canonicalized) [JWT] signed with [`secp256k1`] is as follows:
+A (canonicalized) [JWT] signed with [ES256K] is as follows:
 
 ```
     Varsig
@@ -365,6 +365,7 @@ Our gratitude to [Dave Huseby] for his parallel work and critiques of our earlie
 [DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
 [Dave Huseby]: https://github.com/dhuseby
 [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
+[ES256K]: https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/
 [EdDSA]: https://datatracker.ietf.org/doc/html/rfc8032
 [How (not) to sign a JSON object]: https://latacora.micro.blog/2019/07/24/how-not-to.html
 [Hugo Dias]: https://github.com/hugomrdias

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Ipld::Map([
 The `sig` field is then removed, and the remaining fields serialized to binary;
 
 ``` rust
-Ipld::serialize(
+serialize(
     Ipld::Map([
         ("role", Ipld::String("user")),
         (
@@ -204,9 +204,9 @@ The signature is then checked against the above fields, which passes since there
 
 # Safety
 
-Data that has already been parsed to an in-memory IPLD representation can be canonically encoded trivially: it has already been through a [parser / validator][Parse Don't Validate].
+Data already parsed to an in-memory IPLD representation can be canonically encoded trivially: it has already been through a [parser / validator][Parse Don't Validate].
 
-Data purporting to conform to an IPLD encoding (such as [DAG-JSON]) MUST be validated prior to signature verification. This MAY be as simple as round-trip decoding/encoding the JSON and checking that the hash matches. A validation error MUST be signalled if it does not match.
+Data purporting to conform to an IPLD encoding (such as [DAG-JSON]) MUST be validated prior to signature verification. This MAY be as simple as round-trip decoding/encoding the JSON and checking that the hash matches. A validation error MUST be signaled if it does not match.
 
 > Implementers may provide an opt-in for systems where round-trip determinism is a desireable [sic] feature and backward compatibility with old, non-strict data is unnecessary.
 >
@@ -227,7 +227,7 @@ Signing CIDs has two additional caching consequences:
 
 # Format
 
-A varsig is composed of two main segments:
+A varsig has two main segments:
 
 * [Header]: binary coded signature metadata
 * [Signature]: the signature itself
@@ -251,7 +251,7 @@ Including the varsig header in the payload that is signed over is RECOMMENDED. D
 
 ## Header
 
-A varsig header MUST metadata about both the [signature] and [payload encoding] that was signed over. Either field MAY be composed of one or more segments. The number of segments MUST be determined by the first segment. Recurive sub-segments MAY be used.
+A varsig header MUST metadata about both the [signature] and [payload encoding] that was signed over. Either field MAY be composed of one or more segments. The number of segments MUST be determined by the first segment. Recursive sub-segments MAY be used.
 
 A varsig header MUST begin with one or more varsig segments that desicribe.....
 
@@ -270,7 +270,7 @@ payload-encoding-metadata = unsigned-varint
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-For example, an [RS256] signature over some [DAG-CBOR] would be structured as follows:
+For example, an [RS256] signature over some [DAG-CBOR] is as follows:
  
 ```
    Varisg
@@ -288,7 +288,7 @@ For example, an [RS256] signature over some [DAG-CBOR] would be structured as fo
                             SHA2-256
 ```
 
-A (canonicalized) [JWT] signed with [`secp256k1`] would be strucutured as follows:
+A (canonicalized) [JWT] signed with [`secp256k1`] is as follows:
 
 ```
     Varsig
@@ -331,7 +331,7 @@ varsig-encoding-info
   / %x70                        ; DAG-PB multicodec prefix
   / %x71                        ; DAG-CBOR multicodec prefix
   / %x0129                      ; DAG-JSON multicodec prefix
-  / %x6A77                      ; JWT
+  / %x6A77                      ; Canonicalized JWT
   / %xE191 varsig-encoding-info ; EIP-191 "personal sign"
 ```
 
@@ -342,6 +342,14 @@ The associated signature bytes MUST be represented as a byte array.
 ``` abnf
 varsig-signature-bytes = 1*OCTET
 ```
+
+# Acknowledgments
+
+Many thanks to [Hugo Dias] for feedback on the spec and digging through other approaches to the problem.
+
+Thanks to [Michael Muré] for feedback from real-world implementation.
+
+Our gratitude to [Dave Huseby] for his parallel work and critiques of our earlier design.
 
 <!-- Internal Links -->
 
@@ -355,12 +363,15 @@ varsig-signature-bytes = 1*OCTET
 [CID]: https://docs.ipfs.tech/concepts/content-addressing/
 [DAG-JSON]: https://ipld.io/specs/codecs/dag-json/spec/
 [DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
+[Dave Huseby]: https://github.com/dhuseby
 [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
 [EdDSA]: https://datatracker.ietf.org/doc/html/rfc8032
 [How (not) to sign a JSON object]: https://latacora.micro.blog/2019/07/24/how-not-to.html
+[Hugo Dias]: https://github.com/hugomrdias
 [IPLD Data Model]: https://ipld.io/docs/data-model/kinds/
 [IPLD]: https://ipld.io/docs/
 [JWT]: https://www.rfc-editor.org/rfc/rfc7519
+[Michael Muré]: https://github.com/MichaelMure
 [Multicodec]: https://github.com/multiformats/multicodec
 [Multiformats]: https://multiformats.io
 [PKI Layer Cake]: https://link.springer.com/chapter/10.1007/978-3-642-14577-3_22
@@ -377,4 +388,3 @@ varsig-signature-bytes = 1*OCTET
 [multicodec]: https://github.com/multiformats/multicodec
 [raw binary multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L40
 [unsigned varint]: https://github.com/multiformats/unsigned-varint
- 

--- a/README.md
+++ b/README.md
@@ -315,10 +315,10 @@ The signature algorithm field MUST consist of one or more unsigned varint segmen
 
 ``` abnf
 varsig-signature-algorithm
-  = %x1205 rsa-size hash-algorithm           ; RSASSA-PKCS #1 v1.5
-  / %xB1 bls-public-key-curve hash-algorithm ; BLS
-  / %xEC ecdsa-curve hash-algorithm          ; ECDSA
-  / %xED eddsa-curve hash-algorithm          ; EdDSA
+  = %xB1   bls-public-key-curve        multihash-header ; BLS
+  / %xEC   ecdsa-curve recovery-parity multihash-header ; ECDSA
+  / %xED   eddsa-curve                 multihash-header ; EdDSA
+  / %x1205 rsa-size                    multihash-header ; RSASSA-PKCS #1 v1.5
 ```
 
 ### Payload Encoding Metadata

--- a/common.md
+++ b/common.md
@@ -1,0 +1,151 @@
+# Appendix: Common Varsig Headers
+
+Below are a few common signature headers and their fields.
+
+## RSA
+
+[RSASSA-PKCS #1 v1.5] signatures MUST include the following segments:
+
+``` abnf
+rsa-varsig = rsa-varsig-header rsa-hash-algorithm signature-byte-length
+rsa-prefix = %x1205 ; RSASSA-PKCS #1 v1.5
+rsa-hash-algorithm = unsigned-varint
+signature-byte-length = unsigned-varint
+```
+
+### Example: RS256
+
+| Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
+|----------------------|-------------|-----------------|-----------------------------------------|
+| `rsa-prefix`  | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
+| `rsa-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix            |
+
+### Example: RS512
+
+| Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
+|----------------------|-------------|-----------------|-----------------------------------------|
+| `rsa-prefix`  | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
+| `rsa-hash-algorithm` | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix            |
+
+## [EdDSA]
+
+``` abnf
+eddsa-varsig = ed25519-prefix eddsa-curve eddsa-hash-algorithm
+eddsa-prefix = %xED
+eddsa-curve = unsigned-varint
+eddsa-hash-algorithm = unsigned-varint
+```
+
+### Example: Ed25519
+
+| Segment                 | Hexadecimal | Unsigned Varint | Comment                         | 
+|-------------------------|-------------|-----------------|---------------------------------|
+| `eddsa-prefix`          | `0xED`      | `0xED01`        | EdDSA prefix
+| `eddsa-curve`           | `0xEC`      | `0xEC01`        | Curve25519 [multicodec] prefix | DOUBLE CHECK
+| `eddsa-hash-algorithm`  | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix    |
+
+### Example: Ed448
+
+0x1203
+
+| Segment                 | Hexadecimal | Unsigned Varint | Comment                         | 
+|-------------------------|-------------|-----------------|---------------------------------|
+| `eddsa-prefix`          | `0xED`      | `0xED01`        | EdDSA prefix
+| `eddsa-curve`           | FIXME      | FIXME        | Curve448 [multicodec] prefix | DOUBLE CHECK
+| `eddsa-hash-algorithm`  | `0x19`      | `0x19`          | SHAKE-256 [multicodec] prefix    |
+
+## ECDSA
+
+ECDSA defines a general mechanism over many elliptic curves. 
+
+``` abnf
+ecdsa-varsig = ecdsa-varsig-header ecdsa-hash-algorithm encoding-info sig-bytes
+
+ecdsa-varsig-header = unsigned-varint
+ecdsa-hash-algorithm = unsigned-varint
+encoding-info = 1*unsigned-varint
+sig-bytes = *OCTET
+```
+
+Here are a few examples encoded as varsig:
+
+### Example: ES256
+
+``` abnf
+es256-varsig = es256-varsig-header es256-hash-algorithm encoding-info sig-bytes
+es256-prefix = %x1200 ; P-256 multicodec prefix
+es256-hash-algorithm = %x12 ; SHA2-256
+```
+
+| Segment                | Hexadecimal | Unsigned Varint | Comment                      | 
+|------------------------|-------------|-----------------|------------------------------|
+| `es256-prefix`  | `0x1200`    | `0x8024`        | P-256 [multicodec] prefix    |
+| `es256-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix |
+
+### Example: ES256K
+
+``` abnf
+es256k-varsig = es256k-varsig-header es256k-hash-algorithm encoding-info sig-bytes
+
+es256k-varsig-header = %xe7 ; secp256k1 multicodec prefix
+es256k-hash-algorithm = %x12 ; SHA2-256
+encoding-info = 1*unsigned-varint
+sig-bytes = 64(OCTET)
+```
+
+| Segment                 | Hexadecimal | Unsigned Varint | Comment                        | 
+|-------------------------|-------------|-----------------|--------------------------------|
+| `es256k-varsig-header`  | `0xE7`      | `0xE701`        | secp256k1 [multicodec] prefix  |
+| `es256k-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix   |
+
+### Example: ES512
+
+``` abnf
+es512-varsig = es512-varsig-header es512-hash-algorithm encoding-info sig-bytes
+
+es512-varsig-header = %x1202 ; P-521 multicodec prefix
+es512-hash-algorithm = %x13 ; SHA2-512
+encoding-info = 1*unsigned-varint
+sig-bytes = 128(OCTET)
+```
+
+| Segment                | Hexadecimal | Unsigned Varint | Comment                      | 
+|------------------------|-------------|-----------------|------------------------------|
+| `es512-varsig-header`  | `0x1202`    | `0x8224`        | P-521 [multicodec] prefix    |
+| `es512-hash-algorithm` | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix |
+
+<!-- Internal Links -->
+
+[Header]: #header
+[Signature]: #signature
+[Common Signature Algorithms]: #common-signature-algorithms
+
+<!-- External Links -->
+
+[CAR]: https://ipld.io/specs/transport/car/
+[CID]: https://docs.ipfs.tech/concepts/content-addressing/
+[DAG-JSON]: https://ipld.io/specs/codecs/dag-json/spec/
+[DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
+[EIP-191]: https://eips.ethereum.org/EIPS/eip-191
+[EdDSA]: https://datatracker.ietf.org/doc/html/rfc8032
+[How (not) to sign a JSON object]: https://latacora.micro.blog/2019/07/24/how-not-to.html
+[IPLD Data Model]: https://ipld.io/docs/data-model/kinds/
+[IPLD]: https://ipld.io/docs/
+[JWT]: https://www.rfc-editor.org/rfc/rfc7519
+[Multicodec]: https://github.com/multiformats/multicodec
+[Multiformats]: https://multiformats.io
+[PKI Layer Cake]: https://link.springer.com/chapter/10.1007/978-3-642-14577-3_22
+[Parse Don't Validate]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[RFC 7519]: https://www.rfc-editor.org/rfc/rfc7519
+[RFC 8259]: https://www.rfc-editor.org/rfc/rfc8259#page-10
+[RSASSA-PKCS #1 v1.5]: https://www.rfc-editor.org/rfc/rfc2313
+[Taxonomy of Attacks]: https://www.blackhat.com/presentations/bh-usa-07/Hill/Whitepaper/bh-usa-07-hill-WP.pdf
+[`secp256k1`]: https://en.bitcoin.it/wiki/Secp256k1
+[base64]: https://en.wikipedia.org/wiki/Base64
+[canonicalization attacks]: https://soatok.blog/2021/07/30/canonicalization-attacks-against-macs-and-signatures/
+[multibase]: https://github.com/multiformats/multibase
+[multicodec]: https://github.com/multiformats/multicodec
+[raw binary multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L40
+[unsigned varint]: https://github.com/multiformats/unsigned-varint
+

--- a/common.md
+++ b/common.md
@@ -15,16 +15,16 @@ signature-byte-length = unsigned-varint
 
 ### Example: RS256
 
-| Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
+| Segment              | Hexadecimal | Unsigned Varint | Comment                                 |
 |----------------------|-------------|-----------------|-----------------------------------------|
-| `rsa-prefix`  | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
+| `rsa-prefix`         | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
 | `rsa-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix            |
 
 ### Example: RS512
 
-| Segment              | Hexadecimal | Unsigned Varint | Comment                                 | 
+| Segment              | Hexadecimal | Unsigned Varint | Comment                                 |
 |----------------------|-------------|-----------------|-----------------------------------------|
-| `rsa-prefix`  | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
+| `rsa-prefix`         | `0x1205`    | `0x8524`        | RSASSA-PKCS #1 v1.5 [multicodec] prefix |
 | `rsa-hash-algorithm` | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix            |
 
 ## [EdDSA]
@@ -38,11 +38,11 @@ eddsa-hash-algorithm = unsigned-varint
 
 ### Example: Ed25519
 
-| Segment                 | Hexadecimal | Unsigned Varint | Comment                         | 
-|-------------------------|-------------|-----------------|---------------------------------|
-| `eddsa-prefix`          | `0xED`      | `0xED01`        | EdDSA prefix
-| `eddsa-curve`           | `0xEC`      | `0xEC01`        | Curve25519 [multicodec] prefix | DOUBLE CHECK
-| `eddsa-hash-algorithm`  | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix    |
+| Segment                | Hexadecimal | Unsigned Varint | Comment                        |              |
+|------------------------|-------------|-----------------|--------------------------------|--------------|
+| `eddsa-prefix`         | `0xED`      | `0xED01`        | EdDSA prefix                   |              |
+| `eddsa-curve`          | `0xEC`      | `0xEC01`        | Curve25519 [multicodec] prefix | DOUBLE CHECK |
+| `eddsa-hash-algorithm` | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix   |              |
 
 ### Example: Ed448
 

--- a/common.md
+++ b/common.md
@@ -48,11 +48,11 @@ eddsa-hash-algorithm = unsigned-varint
 
 0x1203
 
-| Segment                 | Hexadecimal | Unsigned Varint | Comment                         | 
-|-------------------------|-------------|-----------------|---------------------------------|
-| `eddsa-prefix`          | `0xED`      | `0xED01`        | EdDSA prefix
-| `eddsa-curve`           | FIXME      | FIXME        | Curve448 [multicodec] prefix | DOUBLE CHECK
-| `eddsa-hash-algorithm`  | `0x19`      | `0x19`          | SHAKE-256 [multicodec] prefix    |
+| Segment                | Hexadecimal | Unsigned Varint | Comment                       |
+|------------------------|-------------|-----------------|-------------------------------|
+| `eddsa-prefix`         | `0xED`      | `0xED01`        | EdDSA prefix                  |
+| `eddsa-curve`          | `0x1203`    | `0x8324`        | Curve448 [multicodec] prefix  |
+| `eddsa-hash-algorithm` | `0x19`      | `0x19`          | SHAKE-256 [multicodec] prefix |
 
 ## ECDSA
 
@@ -77,9 +77,10 @@ es256-prefix = %x1200 ; P-256 multicodec prefix
 es256-hash-algorithm = %x12 ; SHA2-256
 ```
 
-| Segment                | Hexadecimal | Unsigned Varint | Comment                      | 
+| Segment                | Hexadecimal | Unsigned Varint | Comment                      |
 |------------------------|-------------|-----------------|------------------------------|
-| `es256-prefix`  | `0x1200`    | `0x8024`        | P-256 [multicodec] prefix    |
+| `ecdsa-prefix`         | `0xEC`      | `0xEC01`        | ECDSA                        |
+| `es256-prefix`         | `0x1200`    | `0x8024`        | P-256 [multicodec] prefix    |
 | `es256-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix |
 
 ### Example: ES256K
@@ -93,10 +94,11 @@ encoding-info = 1*unsigned-varint
 sig-bytes = 64(OCTET)
 ```
 
-| Segment                 | Hexadecimal | Unsigned Varint | Comment                        | 
-|-------------------------|-------------|-----------------|--------------------------------|
-| `es256k-varsig-header`  | `0xE7`      | `0xE701`        | secp256k1 [multicodec] prefix  |
-| `es256k-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix   |
+| Segment                 | Hexadecimal | Unsigned Varint | Comment                       |
+|-------------------------|-------------|-----------------|-------------------------------|
+| `ecdsa-prefix`          | `0xEC`      | `0xEC01`        | ECDSA                         |
+| `es256k-varsig-header`  | `0xE7`      | `0xE701`        | secp256k1 [multicodec] prefix |
+| `es256k-hash-algorithm` | `0x12`      | `0x12`          | SHA2-256 [multicodec] prefix  |
 
 ### Example: ES512
 
@@ -111,6 +113,7 @@ sig-bytes = 128(OCTET)
 
 | Segment                | Hexadecimal | Unsigned Varint | Comment                      | 
 |------------------------|-------------|-----------------|------------------------------|
+| `ecdsa-prefix`         | `0xEC`      | `0xEC01`        | ECDSA                        |
 | `es512-varsig-header`  | `0x1202`    | `0x8224`        | P-521 [multicodec] prefix    |
 | `es512-hash-algorithm` | `0x13`      | `0x13`          | SHA2-512 [multicodec] prefix |
 


### PR DESCRIPTION
[📚 Preview](https://github.com/expede/varsig/blob/consistency/README.md)

This may turn into a 1.0-rc... we'll see.

This is based on a few conversations where folks were unhappy with the design-by-committee prior version. My goals here are to not change any existing code, but adjust the _conceptual_ groupings. This helps implementers make some assumptions about the structure of a varisg, and can effect how future extensions work.